### PR TITLE
Add finetuning capabilities with modular head

### DIFF
--- a/documentation/pretraining_and_finetuning.md
+++ b/documentation/pretraining_and_finetuning.md
@@ -77,6 +77,17 @@ Specify the checkpoint in PATH_TO_CHECKPOINT.
 
 When loading pretrained weights, all layers except the segmentation layers will be used! 
 
-So far there are no specific nnUNet trainers for fine tuning, so the current recommendation is to just use 
-nnUNetTrainer. You can however easily write your own trainers with learning rate ramp up, fine-tuning of segmentation 
-heads or shorter training time.
+Starting with version 2.6, nnU-Net ships with a dedicated `nnUNetTrainerFinetune` that simplifies common
+fine-tuning scenarios. It supports four modes which control which parts of the network are trained:
+
+- `scratch`: train the full network from random initialization.
+- `head`: freeze encoder and decoder and only train the segmentation head.
+- `decoder_head`: freeze the encoder and train decoder plus head.
+- `all`: load weights for all modules and train everything.
+
+Pretrained weights for the encoder, decoder and head can be provided individually using the
+`--encoder_weights`, `--decoder_weights` and `--head_weights` command line arguments of `nnUNetv2_train`.
+The chosen mode is passed via `--finetune_mode`.
+
+During training additional files `encoder.pth`, `decoder.pth` and `head.pth` are written next to the regular
+checkpoints. These can be reused to build a library of pretrained components.

--- a/nnunetv2/model_sharing/model_export.py
+++ b/nnunetv2/model_sharing/model_export.py
@@ -40,6 +40,10 @@ def export_pretrained_model(dataset_name_or_id: Union[int, str], output_file: st
                 for chk in save_checkpoints:
                     source_file = join(trainer_output_dir, fold_folder, chk)
                     zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                for mod_file in ("encoder.pth", "decoder.pth", "head.pth"):
+                    source_file = join(trainer_output_dir, fold_folder, mod_file)
+                    if isfile(source_file):
+                        zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
 
                 # progress.png
                 source_file = join(trainer_output_dir, fold_folder, "progress.png")

--- a/nnunetv2/network_architecture/__init__.py
+++ b/nnunetv2/network_architecture/__init__.py
@@ -1,0 +1,3 @@
+from .plainconv_unet_head import PlainConvUNetHead
+
+__all__ = ["PlainConvUNetHead"]

--- a/nnunetv2/network_architecture/plainconv_unet_head.py
+++ b/nnunetv2/network_architecture/plainconv_unet_head.py
@@ -1,0 +1,88 @@
+import numpy as np
+import torch
+from torch import nn
+from dynamic_network_architectures.architectures.unet import PlainConvUNet
+from torch.nn.modules.conv import _ConvNd
+from torch.nn.modules.dropout import _DropoutNd
+from typing import Union, Type, List, Tuple
+
+
+class PlainConvUNetHead(PlainConvUNet):
+    """PlainConvUNet with the last decoder block separated into `head`."""
+
+    def __init__(self,
+                 input_channels: int,
+                 n_stages: int,
+                 features_per_stage: Union[int, List[int], Tuple[int, ...]],
+                 conv_op: Type[_ConvNd],
+                 kernel_sizes: Union[int, List[int], Tuple[int, ...]],
+                 strides: Union[int, List[int], Tuple[int, ...]],
+                 n_conv_per_stage: Union[int, List[int], Tuple[int, ...]],
+                 num_classes: int,
+                 n_conv_per_stage_decoder: Union[int, Tuple[int, ...], List[int]],
+                 conv_bias: bool = False,
+                 norm_op: Union[None, Type[nn.Module]] = None,
+                 norm_op_kwargs: dict = None,
+                 dropout_op: Union[None, Type[_DropoutNd]] = None,
+                 dropout_op_kwargs: dict = None,
+                 nonlin: Union[None, Type[torch.nn.Module]] = None,
+                 nonlin_kwargs: dict = None,
+                 deep_supervision: bool = False,
+                 nonlin_first: bool = False):
+        super().__init__(input_channels, n_stages, features_per_stage, conv_op,
+                         kernel_sizes, strides, n_conv_per_stage, num_classes,
+                         n_conv_per_stage_decoder, conv_bias, norm_op,
+                         norm_op_kwargs, dropout_op, dropout_op_kwargs, nonlin,
+                         nonlin_kwargs, deep_supervision, nonlin_first)
+
+        # move last decoder stage to head
+        self.head = nn.ModuleDict({
+            'transpconv': self.decoder.transpconvs[-1],
+            'stage': self.decoder.stages[-1],
+            'seg_layer': self.decoder.seg_layers[-1]
+        })
+        self.decoder.transpconvs = self.decoder.transpconvs[:-1]
+        self.decoder.stages = self.decoder.stages[:-1]
+        self.decoder.seg_layers = self.decoder.seg_layers[:-1]
+
+    def forward(self, x):
+        skips = self.encoder(x)
+        lres_input = skips[-1]
+        seg_outputs = []
+        for s in range(len(self.decoder.stages)):
+            y = self.decoder.transpconvs[s](lres_input)
+            y = torch.cat((y, skips[-(s + 2)]), 1)
+            y = self.decoder.stages[s](y)
+            if self.decoder.deep_supervision:
+                seg_outputs.append(self.decoder.seg_layers[s](y))
+            lres_input = y
+
+        y = self.head['transpconv'](lres_input)
+        y = torch.cat((y, skips[0]), 1)
+        y = self.head['stage'](y)
+        seg = self.head['seg_layer'](y)
+        seg_outputs.append(seg)
+        seg_outputs = seg_outputs[::-1]
+        if not self.decoder.deep_supervision:
+            return seg_outputs[0]
+        return seg_outputs
+
+    def compute_conv_feature_map_size(self, input_size):
+        from dynamic_network_architectures.building_blocks.helper import convert_conv_op_to_dim
+        assert len(input_size) == convert_conv_op_to_dim(self.encoder.conv_op)
+        skip_sizes = []
+        for s in range(len(self.encoder.strides) - 1):
+            skip_sizes.append([i // j for i, j in zip(input_size, self.encoder.strides[s])])
+            input_size = skip_sizes[-1]
+        assert len(skip_sizes) == len(self.decoder.stages) + 1
+
+        output = np.int64(0)
+        for s in range(len(self.decoder.stages)):
+            output += self.decoder.stages[s].compute_conv_feature_map_size(skip_sizes[-(s + 1)])
+            output += np.prod([self.encoder.output_channels[-(s + 2)], *skip_sizes[-(s + 1)]], dtype=np.int64)
+            if self.decoder.deep_supervision:
+                output += np.prod([self.decoder.num_classes, *skip_sizes[-(s + 1)]], dtype=np.int64)
+        output += self.head['stage'].compute_conv_feature_map_size(skip_sizes[0])
+        output += np.prod([self.encoder.output_channels[0], *skip_sizes[0]], dtype=np.int64)
+        output += np.prod([self.head['seg_layer'].out_channels, *skip_sizes[0]], dtype=np.int64)
+        return output

--- a/nnunetv2/run/run_training.py
+++ b/nnunetv2/run/run_training.py
@@ -34,7 +34,11 @@ def get_trainer_from_args(dataset_name_or_id: Union[int, str],
                           fold: int,
                           trainer_name: str = 'nnUNetTrainer',
                           plans_identifier: str = 'nnUNetPlans',
-                          device: torch.device = torch.device('cuda')):
+                          device: torch.device = torch.device('cuda'),
+                          finetune_mode: str = 'scratch',
+                          encoder_weights: str | None = None,
+                          decoder_weights: str | None = None,
+                          head_weights: str | None = None):
     # load nnunet class and do sanity checks
     nnunet_trainer = recursive_find_python_class(join(nnunetv2.__path__[0], "training", "nnUNetTrainer"),
                                                 trainer_name, 'nnunetv2.training.nnUNetTrainer')
@@ -62,8 +66,17 @@ def get_trainer_from_args(dataset_name_or_id: Union[int, str],
     plans_file = join(preprocessed_dataset_folder_base, plans_identifier + '.json')
     plans = load_json(plans_file)
     dataset_json = load_json(join(preprocessed_dataset_folder_base, 'dataset.json'))
+    init_params = inspect.signature(nnunet_trainer.__init__).parameters
+    extra = {}
+    if 'finetune_mode' in init_params:
+        extra = {
+            'finetune_mode': finetune_mode,
+            'encoder_weights': encoder_weights,
+            'decoder_weights': decoder_weights,
+            'head_weights': head_weights,
+        }
     nnunet_trainer = nnunet_trainer(plans=plans, configuration=configuration, fold=fold,
-                                    dataset_json=dataset_json, device=device)
+                                    dataset_json=dataset_json, device=device, **extra)
     return nnunet_trainer
 
 
@@ -108,11 +121,17 @@ def cleanup_ddp():
 
 
 def run_ddp(rank, dataset_name_or_id, configuration, fold, tr, p, disable_checkpointing, c, val,
-            pretrained_weights, npz, val_with_best, world_size):
+            pretrained_weights, npz, val_with_best, world_size,
+            finetune_mode, encoder_weights, decoder_weights, head_weights):
     setup_ddp(rank, world_size)
     torch.cuda.set_device(torch.device('cuda', dist.get_rank()))
 
-    nnunet_trainer = get_trainer_from_args(dataset_name_or_id, configuration, fold, tr, p)
+    nnunet_trainer = get_trainer_from_args(dataset_name_or_id, configuration, fold, tr, p,
+                                           device=torch.device('cuda', dist.get_rank()),
+                                           finetune_mode=finetune_mode,
+                                           encoder_weights=encoder_weights,
+                                           decoder_weights=decoder_weights,
+                                           head_weights=head_weights)
 
     if disable_checkpointing:
         nnunet_trainer.disable_checkpointing = disable_checkpointing
@@ -139,6 +158,10 @@ def run_training(dataset_name_or_id: Union[str, int],
                  trainer_class_name: str = 'nnUNetTrainer',
                  plans_identifier: str = 'nnUNetPlans',
                  pretrained_weights: Optional[str] = None,
+                 finetune_mode: str = 'scratch',
+                 encoder_weights: str | None = None,
+                 decoder_weights: str | None = None,
+                 head_weights: str | None = None,
                  num_gpus: int = 1,
                  export_validation_probabilities: bool = False,
                  continue_training: bool = False,
@@ -185,12 +208,26 @@ def run_training(dataset_name_or_id: Union[str, int],
                      pretrained_weights,
                      export_validation_probabilities,
                      val_with_best,
-                     num_gpus),
+                     num_gpus,
+                     finetune_mode,
+                     encoder_weights,
+                     decoder_weights,
+                     head_weights),
                  nprocs=num_gpus,
                  join=True)
     else:
-        nnunet_trainer = get_trainer_from_args(dataset_name_or_id, configuration, fold, trainer_class_name,
-                                               plans_identifier, device=device)
+        nnunet_trainer = get_trainer_from_args(
+            dataset_name_or_id,
+            configuration,
+            fold,
+            trainer_class_name,
+            plans_identifier,
+            device=device,
+            finetune_mode=finetune_mode,
+            encoder_weights=encoder_weights,
+            decoder_weights=decoder_weights,
+            head_weights=head_weights,
+        )
 
         if disable_checkpointing:
             nnunet_trainer.disable_checkpointing = disable_checkpointing
@@ -227,6 +264,14 @@ def run_training_entry():
     parser.add_argument('-pretrained_weights', type=str, required=False, default=None,
                         help='[OPTIONAL] path to nnU-Net checkpoint file to be used as pretrained model. Will only '
                              'be used when actually training. Beta. Use with caution.')
+    parser.add_argument('--finetune_mode', type=str, default='scratch', required=False,
+                        help='[OPTIONAL] Finetuning mode: scratch, head, decoder_head or all')
+    parser.add_argument('--encoder_weights', type=str, default=None, required=False,
+                        help='[OPTIONAL] path to encoder weights for fine-tuning')
+    parser.add_argument('--decoder_weights', type=str, default=None, required=False,
+                        help='[OPTIONAL] path to decoder weights for fine-tuning')
+    parser.add_argument('--head_weights', type=str, default=None, required=False,
+                        help='[OPTIONAL] path to head weights for fine-tuning')
     parser.add_argument('-num_gpus', type=int, default=1, required=False,
                         help='Specify the number of GPUs to use for training')
     parser.add_argument('--npz', action='store_true', required=False,
@@ -264,9 +309,25 @@ def run_training_entry():
     else:
         device = torch.device('mps')
 
-    run_training(args.dataset_name_or_id, args.configuration, args.fold, args.tr, args.p, args.pretrained_weights,
-                 args.num_gpus, args.npz, args.c, args.val, args.disable_checkpointing, args.val_best,
-                 device=device)
+    run_training(
+        args.dataset_name_or_id,
+        args.configuration,
+        args.fold,
+        args.tr,
+        args.p,
+        args.pretrained_weights,
+        args.num_gpus,
+        args.npz,
+        args.c,
+        args.val,
+        args.disable_checkpointing,
+        args.val_best,
+        device=device,
+        finetune_mode=args.finetune_mode,
+        encoder_weights=args.encoder_weights,
+        decoder_weights=args.decoder_weights,
+        head_weights=args.head_weights,
+    )
 
 
 if __name__ == '__main__':

--- a/nnunetv2/training/nnUNetTrainer/variants/__init__.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/__init__.py
@@ -1,0 +1,3 @@
+from .nnUNetTrainerFinetune import nnUNetTrainerFinetune
+
+__all__ = ["nnUNetTrainerFinetune"]

--- a/nnunetv2/training/nnUNetTrainer/variants/nnUNetTrainerFinetune.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/nnUNetTrainerFinetune.py
@@ -1,0 +1,86 @@
+import torch
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch._dynamo import OptimizedModule
+
+from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
+
+
+class nnUNetTrainerFinetune(nnUNetTrainer):
+    """Trainer supporting different fine-tuning modes."""
+
+    def __init__(self, plans: dict, configuration: str, fold: int, dataset_json: dict,
+                 device: torch.device = torch.device('cuda'), *,
+                 finetune_mode: str = 'scratch',
+                 encoder_weights: str | None = None,
+                 decoder_weights: str | None = None,
+                 head_weights: str | None = None):
+        super().__init__(plans, configuration, fold, dataset_json, device)
+        self.finetune_mode = finetune_mode
+        self.encoder_weights = encoder_weights
+        self.decoder_weights = decoder_weights
+        self.head_weights = head_weights
+        self.my_init_kwargs.update({
+            'finetune_mode': finetune_mode,
+            'encoder_weights': encoder_weights,
+            'decoder_weights': decoder_weights,
+            'head_weights': head_weights,
+        })
+
+    def _load_module_weights(self, module: nn.Module, path: str | None):
+        if path is not None:
+            sd = torch.load(path, map_location=self.device)
+            module.load_state_dict(sd)
+
+    def _freeze_module(self, module: nn.Module):
+        for p in module.parameters():
+            p.requires_grad = False
+
+    def initialize(self):
+        if not self.was_initialized:
+            super().initialize()
+            # unwrap if compiled/DDP
+            if self.is_ddp:
+                mod = self.network.module
+            else:
+                mod = self.network
+            if isinstance(mod, OptimizedModule):
+                mod = mod._orig_mod
+
+            # load pretrained weights
+            self._load_module_weights(mod.encoder, self.encoder_weights)
+            self._load_module_weights(mod.decoder, self.decoder_weights)
+            if hasattr(mod, 'head'):
+                self._load_module_weights(mod.head, self.head_weights)
+
+            # freeze according to mode
+            mode = self.finetune_mode.lower()
+            if mode == 'head':
+                self._freeze_module(mod.encoder)
+                self._freeze_module(mod.decoder)
+            elif mode == 'decoder_head':
+                self._freeze_module(mod.encoder)
+            elif mode in ('all', 'scratch'):
+                pass
+            else:
+                raise ValueError(f'Unknown finetune_mode {self.finetune_mode}')
+
+            # reconfigure optimizer with correct parameters
+            self.optimizer, self.lr_scheduler = self.configure_optimizers()
+        else:
+            raise RuntimeError('initialize called twice')
+
+    def save_checkpoint(self, filename: str) -> None:
+        super().save_checkpoint(filename)
+        if self.local_rank == 0 and not self.disable_checkpointing:
+            if self.is_ddp:
+                mod = self.network.module
+            else:
+                mod = self.network
+            if isinstance(mod, OptimizedModule):
+                mod = mod._orig_mod
+            torch.save(mod.encoder.state_dict(), self.output_folder + '/encoder.pth')
+            torch.save(mod.decoder.state_dict(), self.output_folder + '/decoder.pth')
+            if hasattr(mod, 'head'):
+                torch.save(mod.head.state_dict(), self.output_folder + '/head.pth')
+

--- a/nnunetv2/utilities/plans_handling/plans_handler.py
+++ b/nnunetv2/utilities/plans_handling/plans_handler.py
@@ -42,6 +42,8 @@ class ConfigurationManager(object):
             unet_class_name = self.configuration["UNet_class_name"]
             if unet_class_name == "PlainConvUNet":
                 network_class_name = "dynamic_network_architectures.architectures.unet.PlainConvUNet"
+            elif unet_class_name == "PlainConvUNetHead":
+                network_class_name = "nnunetv2.network_architecture.plainconv_unet_head.PlainConvUNetHead"
             elif unet_class_name == 'ResidualEncoderUNet':
                 network_class_name = "dynamic_network_architectures.architectures.residual_unet.ResidualEncoderUNet"
             else:


### PR DESCRIPTION
## Summary
- introduce `PlainConvUNetHead` that exposes the last decoder block as a dedicated head
- add `nnUNetTrainerFinetune` with multiple fine-tuning modes and module weight loading
- extend command line options to handle fine-tuning
- export encoder/decoder/head weights in `model_export`
- document the pretraining and fine-tuning workflow
- update plan conversion to recognise `PlainConvUNetHead`

## Testing
- `python -m py_compile nnunetv2/network_architecture/plainconv_unet_head.py nnunetv2/training/nnUNetTrainer/variants/nnUNetTrainerFinetune.py nnunetv2/run/run_training.py nnunetv2/model_sharing/model_export.py nnunetv2/utilities/plans_handling/plans_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_688c4804f9c0833095abed735fcaaf5f