### PR TITLE
Add multi-head support to PlainConvUNetHead

### DIFF
--- a/documentation/pretraining_and_finetuning.md
+++ b/documentation/pretraining_and_finetuning.md
@@ -89,5 +89,6 @@ Pretrained weights for the encoder, decoder and head can be provided individuall
 `--encoder_weights`, `--decoder_weights` and `--head_weights` command line arguments of `nnUNetv2_train`.
 The chosen mode is passed via `--finetune_mode`.
 
-During training additional files `encoder.pth`, `decoder.pth` and `head.pth` are written next to the regular
-checkpoints. These can be reused to build a library of pretrained components.
+During training additional files `encoder.pth`, `decoder.pth` and head checkpoints are written next to the
+regular checkpoints. For single-head networks this file is `head.pth`. If multiple heads are present, each is
+stored as `<class_name>_head.pth`. These can be reused to build a library of pretrained components.

--- a/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
@@ -5,8 +5,8 @@ from typing import List, Union, Tuple
 import numpy as np
 import torch
 from batchgenerators.utilities.file_and_folder_operations import load_json, join, save_json, isfile, maybe_mkdir_p
-from dynamic_network_architectures.architectures.unet import PlainConvUNet
 from dynamic_network_architectures.building_blocks.helper import convert_dim_to_conv_op, get_matching_instancenorm
+from nnunetv2.network_architecture.plainconv_unet_head import PlainConvUNetHead
 
 from nnunetv2.configuration import ANISO_THRESHOLD
 from nnunetv2.experiment_planning.experiment_planners.network_topology import get_pool_and_conv_props
@@ -48,7 +48,7 @@ class ExperimentPlanner(object):
         self.anisotropy_threshold = ANISO_THRESHOLD
 
         self.UNet_base_num_features = 32
-        self.UNet_class = PlainConvUNet
+        self.UNet_class = PlainConvUNetHead
         # the following two numbers are really arbitrary and were set to reproduce nnU-Net v1's configurations as
         # much as possible
         self.UNet_reference_val_3d = 560000000  # 455600128  550000000
@@ -98,7 +98,7 @@ class ExperimentPlanner(object):
                                    arch_kwargs: dict,
                                    arch_kwargs_req_import: Tuple[str, ...]):
         """
-        Works for PlainConvUNet, ResidualEncoderUNet
+        Works for PlainConvUNetHead, PlainConvUNet, ResidualEncoderUNet
         """
         a = torch.get_num_threads()
         torch.set_num_threads(get_allowed_n_proc_DA())

--- a/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
@@ -297,6 +297,9 @@ class ExperimentPlanner(object):
             '_kw_requires_import': ('conv_op', 'norm_op', 'dropout_op', 'nonlin'),
         }
 
+        class_names = [k for k in self.dataset_json['labels'].keys() if k != 'ignore']
+        architecture_kwargs['arch_kwargs']['class_names'] = class_names
+
         # now estimate vram consumption
         if _keygen(patch_size, pool_op_kernel_sizes) in _cache.keys():
             estimate = _cache[_keygen(patch_size, pool_op_kernel_sizes)]

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -107,7 +107,7 @@ class nnUNetPredictor(object):
             parameters.append(ckpt["network_weights"])
 
         # 3. 根据 configuration 构建网络
-        config_mgr = plans_manager.get_configuration(configuration_name)
+        config_mgr = plans_manager.get_configuration(configuration_name, dataset_json)
         num_inputs = determine_num_input_channels(plans_manager, config_mgr, dataset_json)
         num_heads  = plans_manager.get_label_manager(dataset_json).num_segmentation_heads
 
@@ -175,7 +175,7 @@ class nnUNetPredictor(object):
 
             parameters.append(checkpoint['network_weights'])
 
-        configuration_manager = plans_manager.get_configuration(configuration_name)
+            configuration_manager = plans_manager.get_configuration(configuration_name, dataset_json)
         # restore network
         num_input_channels = determine_num_input_channels(plans_manager, configuration_manager, dataset_json)
         trainer_class = recursive_find_python_class(join(nnunetv2.__path__[0], "training", "nnUNetTrainer"),

--- a/nnunetv2/model_sharing/model_export.py
+++ b/nnunetv2/model_sharing/model_export.py
@@ -44,6 +44,10 @@ def export_pretrained_model(dataset_name_or_id: Union[int, str], output_file: st
                     source_file = join(trainer_output_dir, fold_folder, mod_file)
                     if isfile(source_file):
                         zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                # include all *_head.pth files for multi-head networks
+                head_files = subfiles(join(trainer_output_dir, fold_folder), join=True, suffix="_head.pth")
+                for hf in head_files:
+                    zipf.write(hf, os.path.relpath(hf, nnUNet_results))
 
                 # progress.png
                 source_file = join(trainer_output_dir, fold_folder, "progress.png")

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -115,7 +115,7 @@ class nnUNetTrainer(object):
 
         ###  Saving all the init args into class variables for later access
         self.plans_manager = PlansManager(plans)
-        self.configuration_manager = self.plans_manager.get_configuration(configuration)
+        self.configuration_manager = self.plans_manager.get_configuration(configuration, dataset_json)
         self.configuration_name = configuration
         self.dataset_json = dataset_json
         self.fold = fold
@@ -1309,7 +1309,7 @@ class nnUNetTrainer(object):
                 # if needed, export the softmax prediction for the next stage
                 if next_stages is not None:
                     for n in next_stages:
-                        next_stage_config_manager = self.plans_manager.get_configuration(n)
+                        next_stage_config_manager = self.plans_manager.get_configuration(n, self.dataset_json)
                         expected_preprocessed_folder = join(nnUNet_preprocessed, self.plans_manager.dataset_name,
                                                             next_stage_config_manager.data_identifier)
                         # next stage may have a different dataset class, do not use self.dataset_class

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -1170,6 +1170,13 @@ class nnUNetTrainer(object):
                     'inference_allowed_mirroring_axes': self.inference_allowed_mirroring_axes,
                 }
                 torch.save(checkpoint, filename)
+
+                # save separate heads if present
+                if hasattr(mod, 'heads'):
+                    for name, head in mod.heads.items():
+                        torch.save(head.state_dict(), os.path.join(self.output_folder, f'{name}_head.pth'))
+                elif hasattr(mod, 'head'):
+                    torch.save(mod.head.state_dict(), os.path.join(self.output_folder, 'head.pth'))
             else:
                 self.print_to_log_file('No checkpoint written, checkpointing is disabled')
 


### PR DESCRIPTION
## Summary
- extend `PlainConvUNetHead` to accept optional class names
- duplicate the last decoder stage per class and build separate heads
- update the forward pass and memory estimate to use all heads

## Testing
- `python -m py_compile nnunetv2/network_architecture/plainconv_unet_head.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c7735cc6083308d0482f5d9c85379